### PR TITLE
Install pleno-droid and pleno-qc on JupyterHub

### DIFF
--- a/roles/jupyterhub/files/netrc
+++ b/roles/jupyterhub/files/netrc
@@ -1,0 +1,6 @@
+machine pypi.plenoinc.com
+login pleno
+password cornerstone
+machine 13.56.49.240
+login pleno
+password cornerstone

--- a/roles/jupyterhub/tasks/qcuser.yml
+++ b/roles/jupyterhub/tasks/qcuser.yml
@@ -66,6 +66,17 @@
   become: true
   become_user: qcuser
 
+- name: Install pleno-droid
+  ansible.builtin.pip:
+    chdir: "{{ qcuser.home }}/pleno-droid"
+    name: .
+    state: present
+    extra_args: --extra-index-url https://pypi.plenoinc.com
+    virtualenv: "{{ qcuser.home }}/qcuser-venv"
+  changed_when: false
+  become: true
+  become_user: qcuser
+
 # Provides visualization code
 - name: Clone pleno-qc.git
   ansible.builtin.git:
@@ -79,8 +90,10 @@
   ansible.builtin.pip:
     chdir: "{{ qcuser.home }}/pleno-qc"
     name:
+      - opencv-python
       - scikit-image
       - parsimonious
+      - matplotlib
       - .
     state: present
     extra_args: --extra-index-url https://pypi.plenoinc.com

--- a/roles/jupyterhub/tasks/qcuser.yml
+++ b/roles/jupyterhub/tasks/qcuser.yml
@@ -75,21 +75,15 @@
   become: true
   become_user: qcuser
 
-# Install pleno-qc dependencies
-- name: Install pleno-qc dependencies
-  ansible.builtin.pip:
-    name: "{{ item }}"
-    state: present
-    virtualenv: "{{ qcuser.home }}/qcuser-venv"
-  loop:
-    - scikit-image
-    - parsimonious
-
 - name: Install pleno-qc
   ansible.builtin.pip:
     chdir: "{{ qcuser.home }}/pleno-qc"
-    name: .
+    name:
+      - scikit-image
+      - parsimonious
+      - .
     state: present
+    extra_args: --extra-index-url https://pypi.plenoinc.com
     virtualenv: "{{ qcuser.home }}/qcuser-venv"
   become: true
   become_user: qcuser


### PR DESCRIPTION
Specific to qcuser account, install pleno-droid and pleno-qc libraries
to the virtual environment at `/home/qcusers/qc-venv/`. Since we are not
yet enabled poetry in `pleno-qc`, manually install dependencies with
pip.