### PR TITLE
Install netrc

### DIFF
--- a/roles/jupyterhub/files/netrc
+++ b/roles/jupyterhub/files/netrc
@@ -1,0 +1,6 @@
+machine pypi.plenoinc.com
+login pleno
+password cornerstone
+machine 13.56.49.240
+login pleno
+password cornerstone

--- a/roles/jupyterhub/tasks/qcuser.yml
+++ b/roles/jupyterhub/tasks/qcuser.yml
@@ -75,21 +75,15 @@
   become: true
   become_user: qcuser
 
-# Install pleno-qc dependencies
-- name: Install pleno-qc dependencies
-  ansible.builtin.pip:
-    name: "{{ item }}"
-    state: present
-    virtualenv: "{{ qcuser.home }}/qcuser-venv"
-  loop:
-    - scikit-image
-    - parsimonious
-
 - name: Install pleno-qc
   ansible.builtin.pip:
     chdir: "{{ qcuser.home }}/pleno-qc"
-    name: .
+    name:
+      - scikit-image
+      - parsimonious
+      - .
     state: present
+    extra_args: --extra-index-url https://pypi.plenoinc.com
     virtualenv: "{{ qcuser.home }}/qcuser-venv"
   become: true
   become_user: qcuser


### PR DESCRIPTION
Assuming Pypy repository has a weak password, install the netrc password file as cleartext having access mode `0644`. Password file encryption only makes sense for strong password.

To install Pleno-QC repo on JupyterHub, permit `pip` to seek for `cp2-droid` package from external URL.

cc'ed @tom-pleno .