### PR TITLE
Enable linux perf with Python3.12

### DIFF
--- a/roles/pleno_droid/defaults/main.yml
+++ b/roles/pleno_droid/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-pleno_droid_rootdir: "{{ ansible_env.HOME }}/Projects/performance-study/"
+pleno_droid_rootdir: "{{ ansible_env.HOME }}/Projects/performance-study"
 pleno_droid_droid2_version: 2.0.1
-pleno_droid_droid2_venv: "{{ pleno_droid_rootdir }}/{{ pleno_droid_droid2_version }}-venv"
+pleno_droid_droid2_venv: "{{ pleno_droid_rootdir }}/{{ pleno_droid_droid2_version }}-py3.12.3-venv"
 pleno_droid_droid1_version: 1.24.1
-pleno_droid_droid1_venv: "{{ pleno_droid_rootdir }}/{{ pleno_droid_droid1_version }}-venv"
+pleno_droid_droid1_venv: "{{ pleno_droid_rootdir }}/{{ pleno_droid_droid1_version }}-py3.12.3-venv"

--- a/roles/pleno_droid/tasks/main.yml
+++ b/roles/pleno_droid/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Setup performance comparison directory
   ansible.builtin.file:
-    path: /home/antony/Projects/performance-study
+    path: "{{ pleno_droid_rootdir }}"
     state: directory
     mode: "0755"
 
@@ -11,7 +11,7 @@
     state: present
     virtualenv: "{{ pleno_droid_droid2_venv }}"
     virtualenv_site_packages: true
-    virtualenv_command: /opt/miniconda3/bin/python3.11 -m venv
+    virtualenv_command: "{{ pyenv_user.home }}/.pyenv/versions/3.12.3/bin/python -m venv"
 
 - name: (Droid2) Install droid and dependencies
   ansible.builtin.pip:
@@ -26,7 +26,7 @@
     state: present
     virtualenv: "{{ pleno_droid_droid1_venv }}"
     virtualenv_site_packages: true
-    virtualenv_command: /opt/miniconda3/bin/python3.11 -m venv
+    virtualenv_command: "{{ pyenv_user.home }}/.pyenv/versions/3.12.3/bin/python -m venv"
 
 - name: (Droid1) Install droid and dependencies
   ansible.builtin.pip:

--- a/roles/pleno_droid/templates/run.sh
+++ b/roles/pleno_droid/templates/run.sh
@@ -2,7 +2,11 @@
 DROID={{ item.venv }}/bin/python
 RUN_FOLDER=/mnt/nas/DecodingRuns/KET-11/20240523_KET11_JW_2412160129_NIPT_3283plex_EXP_071_P2
 
-$DROID -m pleno_droid \
+# Samples per second
+FPS=90
+
+exec perf record -F $FPS -g -o "{{ pleno_droid_rootdir }}/perf-{{ item.version }}.data" \
+$DROID -X perf -m pleno_droid \
 	-i "$RUN_FOLDER" \
 	-o "/mnt/nas/_USERS/Antony/BIOINF-1426-{{ item.version }}" \
 	-c "decode_proto1.yaml" \

--- a/roles/py3.12_linux_perf/files/hello_world.py
+++ b/roles/py3.12_linux_perf/files/hello_world.py
@@ -1,0 +1,33 @@
+import sys
+import sysconfig
+
+def check_perf_support():
+    if sys.version_info < (3, 12):
+        version = sysconfig.get_python_version()
+        raise RuntimeError(f"This is Python {version}, not 3.12 or later")
+
+    if not sysconfig.get_config_var("PY_HAVE_PERF_TRAMPOLINE"):
+        raise RuntimeError("Python doesn't support perf on this platform")
+
+    if not sys.is_stack_trampoline_active():
+        raise RuntimeError("Did you forget the '-X perf' option?")
+
+    cflags = sysconfig.get_config_var("CONFIGURE_CFLAGS")
+    if "-fno-omit-frame-pointer" not in cflags:
+        print("Python compiled without the frame pointer", file=sys.stderr)
+
+def foo(n):
+    result = 0
+    for _ in range(n):
+        result += 1
+    return result
+
+def bar(n):
+    foo(n)
+
+def baz(n):
+    bar(n)
+
+if __name__ == "__main__":
+    check_perf_support()
+    baz(1000000)

--- a/roles/py3.12_linux_perf/files/pyenv
+++ b/roles/py3.12_linux_perf/files/pyenv
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$1" = "--debug" ]; then
+  export PYENV_DEBUG=1
+  shift
+fi
+
+if [ -n "$PYENV_DEBUG" ]; then
+  # https://wiki-dev.bash-hackers.org/scripting/debuggingtips#making_xtrace_more_useful
+  export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+  set -x
+fi
+
+abort() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "pyenv: $*"
+    fi
+  } >&2
+  exit 1
+}
+
+if enable -f "${BASH_SOURCE%/*}"/../libexec/pyenv-realpath.dylib realpath 2>/dev/null; then
+  abs_dirname() {
+    local path
+    path="$(realpath "$1")"
+    echo "${path%/*}"
+  }
+else
+  [ -z "$PYENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
+
+  READLINK=$(type -P readlink)
+  [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
+
+  resolve_link() {
+    $READLINK "$1"
+  }
+
+  abs_dirname() {
+    local path="$1"
+
+    # Use a subshell to avoid changing the current path
+    (
+    while [ -n "$path" ]; do
+      cd_path="${path%/*}"
+      if [[ "$cd_path" != "$path" ]]; then
+        cd "$cd_path"
+      fi
+      name="${path##*/}"
+      path="$(resolve_link "$name" || true)"
+    done
+
+    echo "$PWD"
+    )
+  }
+fi
+
+if [ -z "${PYENV_ROOT}" ]; then
+  PYENV_ROOT="${HOME}/.pyenv"
+else
+  PYENV_ROOT="${PYENV_ROOT%/}"
+fi
+export PYENV_ROOT
+
+if [ -z "${PYENV_DIR}" ]; then
+  PYENV_DIR="$PWD"
+fi
+
+if [ ! -d "$PYENV_DIR" ] || [ ! -e "$PYENV_DIR" ]; then
+  abort "cannot change working directory to \`$PYENV_DIR'"
+fi
+
+PYENV_DIR=$(cd "$PYENV_DIR" && echo "$PWD")
+export PYENV_DIR
+
+
+shopt -s nullglob
+
+bin_path="$(abs_dirname "$0")"
+for plugin_bin in "${bin_path%/*}"/plugins/*/bin; do
+  PATH="${plugin_bin}:${PATH}"
+done
+# PYENV_ROOT can be set to anything, so it may happen to be equal to the base path above,
+# resulting in duplicate PATH entries
+if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then
+  for plugin_bin in "${PYENV_ROOT}"/plugins/*/bin; do
+    PATH="${plugin_bin}:${PATH}"
+  done
+fi
+export PATH="${bin_path}:${PATH}"
+
+PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"
+if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then
+  # Add pyenv's own `pyenv.d` unless pyenv was cloned to PYENV_ROOT
+  PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${bin_path%/*}/pyenv.d"
+fi
+PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:/usr/local/etc/pyenv.d:/etc/pyenv.d:/usr/lib/pyenv/hooks"
+for plugin_hook in "${PYENV_ROOT}/plugins/"*/etc/pyenv.d; do
+  PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${plugin_hook}"
+done
+PYENV_HOOK_PATH="${PYENV_HOOK_PATH#:}"
+export PYENV_HOOK_PATH
+
+shopt -u nullglob
+
+
+command="$1"
+case "$command" in
+"" )
+  { pyenv---version
+    pyenv-help
+  } | abort
+  ;;
+-v | --version )
+  exec pyenv---version
+  ;;
+-h | --help )
+  exec pyenv-help
+  ;;
+* )
+  command_path="$(command -v "pyenv-$command" || true)"
+  if [ -z "$command_path" ]; then
+    if [ "$command" == "shell" ]; then
+      abort "shell integration not enabled. Run \`pyenv init' for instructions."
+    else
+      abort "no such command \`$command'"
+    fi
+  fi
+
+  shift 1
+  if [ "$1" = --help ]; then
+    if [[ "$command" == "sh-"* ]]; then
+      echo "pyenv help \"$command\""
+    else
+      exec pyenv-help "$command"
+    fi
+  else
+    exec "$command_path" "$@"
+  fi
+  ;;
+esac

--- a/roles/py3.12_linux_perf/files/run-perf.sh
+++ b/roles/py3.12_linux_perf/files/run-perf.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+PYTHON={{ pyenv_user.home }}/versions/3.12.0/bin/python
+exec perf record -F 9999 -g $PYTHON -X perf hello_world.py

--- a/roles/py3.12_linux_perf/tasks/main.yml
+++ b/roles/py3.12_linux_perf/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Create a home folder for pyenv
+  ansible.builtin.user:
+    name: pyenv
+    state: present
+    shell: /bin/bash
+    home: /srv/pyenv
+  become: true
+  register: pyenv_user
+
+- name: Install linux-perf tools and Python dependencies
+  ansible.builtin.apt:
+    name:
+      - libbz2-dev
+      - libreadline-dev
+      - libsqlite3-dev
+      - linux-tools-generic
+    state: present
+  become: true
+
+- name: Compile Python 3.12.3 with linux-perf support
+  ansible.builtin.command:
+    cmd: /srv/pyenv/pyenv_src/bin/pyenv install 3.12.3
+    creates: "{{ pyenv_user.home }}/.pyenv/versions/3.12.3"
+  environment:
+    PYTHON_CFLAGS: '-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -O3'
+  become: true
+  become_user: pyenv
+
+- name: Create demo folder
+  ansible.builtin.file:
+    path: "{{ pyenv_user.home }}/demo"
+    state: directory
+    mode: "0755"
+  become: true
+  become_user: pyenv
+
+- name: Install demo code
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ pyenv_user.home }}/demo/{{ item }}"
+    mode: "0644"
+  with_items:
+    - hello_world.py
+    - run-perf.sh
+  become: true
+  become_user: pyenv
+
+# - name: Override Kernel-perf restrictions
+#  ansible.builtin.sysctl:
+#    name: kernel.perf_event_paranoid
+#    value: -1
+#    state: present
+#    sysctl_set: yes
+#  become: yes
+# - name: Disable kptr restriction
+#  ansible.builtin.sysctl:
+#    name: kernel.kptr_restrict
+#    value: 0
+#    state: present
+#    sysctl_set: yes
+#  become: yes


### PR DESCRIPTION
Install linux-perf tools. Create a new user `pyenv` to isolate the environment. Compile Python3.12 from source in order to enable the `linux-perf` feature.

Write a hello_world.py to demonstrate the capability.

TODO: Install `hotspot` GUI on the dev server. Install `Firefox profiler` Electron app so that we don't share our data to outside the company.

Expected output. All python functions are shown in namespace `py::` as if they are C++ symbols.

![image](https://github.com/Pleno-Inc/pleno-ansible/assets/154373121/7b260f03-082f-4dde-939b-400941c8e37f)
