### PR TITLE
Setup NTP server

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -8,3 +8,4 @@
   hosts: dev
   roles:
     - plantuml
+    - ntp_server

--- a/roles/ntp_server/files/ntp.conf
+++ b/roles/ntp_server/files/ntp.conf
@@ -1,0 +1,64 @@
+# /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntp/ntp.drift
+
+# Leap seconds definition provided by tzdata
+leapfile /usr/share/zoneinfo/leap-seconds.list
+
+# Enable this if you want statistics to be logged.
+#statsdir /var/log/ntpstats/
+
+statistics loopstats peerstats clockstats
+filegen loopstats file loopstats type day enable
+filegen peerstats file peerstats type day enable
+filegen clockstats file clockstats type day enable
+
+# Specify one or more NTP servers.
+
+# UCSD NTP server
+pool 132.239.254.49 iburst
+
+# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
+# on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for
+# more information.
+
+#pool 0.ubuntu.pool.ntp.org iburst
+#pool 1.ubuntu.pool.ntp.org iburst
+#pool 2.ubuntu.pool.ntp.org iburst
+#pool 3.ubuntu.pool.ntp.org iburst
+
+# Use Ubuntu's ntp server as a fallback.
+pool ntp.ubuntu.com
+
+# Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
+# details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
+# might also be helpful.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default kod notrap nomodify nopeer noquery limited
+restrict -6 default kod notrap nomodify nopeer noquery limited
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Needed for adding pool entries
+restrict source notrap nomodify noquery
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+
+# If you want to provide time to your local subnet, change the next line.
+# (Again, the address is an example only.)
+#broadcast 192.168.123.255
+
+# If you want to listen to time broadcasts on your local subnet, de-comment the
+# next lines.  Please do this only if you trust everybody on the network!
+#disable auth
+#broadcastclient

--- a/roles/ntp_server/handlers/main.yml
+++ b/roles/ntp_server/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart NTP
+  ansible.builtin.service:
+    name: ntp
+    state: restarted
+    enabled: true
+  become: true

--- a/roles/ntp_server/tasks/main.yml
+++ b/roles/ntp_server/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install NTP server
+  ansible.builtin.apt:
+    name: ntp
+    state: present
+  become: true
+
+- name: Configure NTP server
+  ansible.builtin.copy:
+    src: ntp.conf
+    dest: /etc/ntp.conf
+    mode: "0644"
+  notify: Restart NTP
+  become: true


### PR DESCRIPTION
Install NTP daemon on the dev server. Use the closest super-computing cluster's NTP time server as the primary time source. Fallback to Ubuntu's time server if the primary source is not available.