### PR TITLE
Upgrade pleno-qc and droid for Kelli/Chuong

### DIFF
--- a/roles/jupyterhub/tasks/qcuser.yml
+++ b/roles/jupyterhub/tasks/qcuser.yml
@@ -52,7 +52,7 @@
 - name: Clone pleno-droid.git
   ansible.builtin.git:
     repo: git@github.com:Pleno-Inc/pleno-droid.git
-    version: 71b21f4df4a08cf7436fd28d158b190ffb76f8d0
+    version: 3d65054a997cb70037caaf6893b97f05ae29c01b
     dest: "{{ qcuser.home }}/pleno-droid"
   become: true
   become_user: qcuser
@@ -91,7 +91,7 @@
 - name: Clone pleno-qc.git
   ansible.builtin.git:
     repo: git@github.com:Pleno-Inc/pleno-qc.git
-    version: 066f7260c7ba1c8bdcc626444d6e8564d972d126
+    version: feat/homogeneity-cleanup
     dest: "{{ qcuser.home }}/pleno-qc"
   become: true
   become_user: qcuser
@@ -105,8 +105,7 @@
       - parsimonious
       - matplotlib
       - .
-      # 2024-06-11 (Kelli): Lock to specific pleno-common version for now
-      - pleno-common==6.12.0
+      - pleno-common==6.16.0
       # OpenHTF minimal dependencies
       - colorama>=0.3.9
       - contextlib2>=0.5.1


### PR DESCRIPTION
On JupyterHub server, download the latest source code of pleno-droid and pleno-qc. Resolve dependencies. Install to the virtual environment at `/home/qcusers/qc-venv/`.